### PR TITLE
Added simpleprovider to ORM section

### DIFF
--- a/projects.yml
+++ b/projects.yml
@@ -373,6 +373,8 @@ categories:
           url: https://code.google.com/p/android-active-record/
         - name: Cupboard
           url: https://bitbucket.org/qbusict/cupboard
+        - name: simpleprovider
+          url: https://github.com/Triple-T/simpleprovider
           
     - name: Panels
       projects:


### PR DESCRIPTION
Small library we created to simplify the creation of ContentProviders. Available on Maven Central
