### PR TITLE
Added ProviGen in the ContentProviders section.

### DIFF
--- a/projects.yml
+++ b/projects.yml
@@ -170,6 +170,8 @@ categories:
           url: https://github.com/jakenjarvis/Android-OrmLiteContentProvider
         - name: SimpleProvider
           url: http://triple-t.github.io/simpleprovider/
+        - name: ProviGen
+          url: https://github.com/TimotheeJeannin/ProviGen
       
     - name: Crash Reports
       projects:


### PR DESCRIPTION
Added the ProviGen library in the ContentProviders section. 

https://github.com/TimotheeJeannin/ProviGen

Easily make a ContentProvider from an annotated ContractClass
