### PR TITLE
Remove unnecessary tools

### DIFF
--- a/projects/free.yml
+++ b/projects/free.yml
@@ -724,10 +724,6 @@ categories:
 
     - name: Tools
       projects:
-        - name: Android Action Bar Style Generator
-          url: http://jgilfelt.github.io/android-actionbarstylegenerator
-        - name: Android Holo Colors Generator 
-          url: http://android-holo-colors.com
         - name: AndroidAssetStudio
           url: https://romannurik.github.io/AndroidAssetStudio
         - name: Android Studio Templates


### PR DESCRIPTION
Remove Action Bar Style Generator and Holo Colors Generator from tools section, since they both included in AndroidAssetStudio
