### PR TITLE
AllJoyn for Android added to Networking

### DIFF
--- a/projects/free.yml
+++ b/projects/free.yml
@@ -596,6 +596,8 @@ categories:
           url: https://github.com/stephanenicolas/robospice
         - name: Volley
           url: https://android.googlesource.com/platform/frameworks/volley
+        - name: AllJoyn Android
+          url: https://www.alljoyn.org/docs-and-downloads/android
 
     - name: Object Mocking
       projects:


### PR DESCRIPTION
AllJoyn added to Networking.
AllJoyn is an open source project, and it has the tools you need to add proximal peer-to-peer connectivity in your applications (via WiFi or Bluetooth).
