### PR TITLE
Removed crashlytics from paid list

### DIFF
--- a/projects/paid.yml
+++ b/projects/paid.yml
@@ -24,8 +24,6 @@ categories:
       projects:
         - name: Bugsnag
           url: https://bugsnag.com
-        - name: Crashlytics
-          url: http://try.crashlytics.com
         - name: Crittercism
           url: http://www.crittercism.com
         - name: BugSense


### PR DESCRIPTION
It is already in the free list and it is free.
