### PR TITLE
Add Kickflip SDK and Kickflip Example to appropriate lists

### DIFF
--- a/projects/demo.yml
+++ b/projects/demo.yml
@@ -86,3 +86,8 @@ categories:
           url: https://github.com/ksksue/Android-USB-Serial-Monitor-Lite
         - name: USB Device Info
           url: https://github.com/alt236/USB-Device-Info---Android
+
+    - name: Video 
+      projects:
+        - name: Kickflip Android Example 
+          url: https://github.com/Kickflip/kickflip-android-example

--- a/projects/paid.yml
+++ b/projects/paid.yml
@@ -173,5 +173,7 @@ categories:
 
     - name: Video
       projects:
+        - name: Kickflip 
+          url: https://github.com/Kickflip/kickflip-android-sdk/
         - name: Vitamio
           url: https://github.com/yixia/VitamioBundle/


### PR DESCRIPTION
Hello!

This pull requests adds the Kickflip SDKs and Example application to the Android-Aresenal list.

Kickflip is an SDK to make it incredibly easy to add live video streaming to mobile applications - you can learn more at https://kickflip.io

The SDK is Free and Open source, but the Kickflip API is paid, so I have added this to the paid section.

Thanks for doing this project! It's a super useful resource for me.

Rich
