### PR TITLE
Add Application Architecture category in demos, u2020 and u2020-mortar apps

### DIFF
--- a/projects/demo.yml
+++ b/projects/demo.yml
@@ -14,6 +14,13 @@ categories:
         - name: Transition Backport
           url: https://github.com/guerwan/TransitionsBackport
 
+    - name: Application Architecture
+      projects:
+        - name: u2020
+          url: https://github.com/JakeWharton/u2020
+        - name: u2020-mortar
+          url: https://github.com/lemonlabs/u2020-mortar
+
     - name: Audio
       projects:
         - name: tomahawk-android


### PR DESCRIPTION
New category in demos - Application Architecture. It covers demo apps that show how to build application code structure using several techniques and open-source libraries.
And few examples:
- [u2020](https://github.com/JakeWharton/u2020) - a sample app by Jake Wharton that shows how to use Dagger and many other libraries.
- [u2020-mortar](https://github.com/lemonlabs/u2020-mortar) - port of u2020 by lemonlabs that uses Mortar and Flow libraries.
