### PR TITLE
Added the library Saguaro underneath the Changelog category

### DIFF
--- a/projects/free.yml
+++ b/projects/free.yml
@@ -87,6 +87,8 @@ categories:
       projects:
         - name: jReddit
           url: https://github.com/karan/jReddit
+        - name: Twitter4J
+          url: http://twitter4j.org/en/index.html
 
     - name: Architecture
       projects:


### PR DESCRIPTION
According to their GitHub page, Saguaro is "An Android library to make it easier to add version information and licensing information, and facilitate sending feedback.". Since Saguaro is a library that offers functionality for quite a few different things, it was difficult to decide under which category to place it. So instead of adding it under multiple different categories, I just went ahead and placed it underneath Changelog. 

EDIT: I also went ahead and created a new category called "API Wrappers" and placed jReddit and Twitter4J underneath it.
