### PR TITLE
NoCropper project added

### DIFF
--- a/projects/free.yml
+++ b/projects/free.yml
@@ -630,6 +630,8 @@ categories:
           url: https://github.com/biokys/cropimage
         - name: Cropper
           url: https://github.com/edmodo/cropper
+        - name: NoCropper
+          url: https://github.com/jayrambhia/CropperNoCropper
 
     - name: Image Loaders
       projects:


### PR DESCRIPTION
NoCropper is a lightweight square image cropping library which replicates Instagram's new Image Cropper.