### PR TITLE
Added Permiso, a runtime permissions library.

### DIFF
--- a/projects/free.yml
+++ b/projects/free.yml
@@ -1041,6 +1041,11 @@ categories:
         - name: PDFView
           url: https://github.com/JoanZapata/android-pdfview
 
+    - name: Permissions
+      projects:
+        - name: Permiso
+          url: https://github.com/greysonp/permiso
+
     - name: Physics Engines
       projects:
         - name: androidbox2d


### PR DESCRIPTION
Permiso helps manage runtime permissions. Added the Permissions category, which is already present on android-arsenal.com.