### PR TITLE
Add SnackbarBuilder library

### DIFF
--- a/projects/free.yml
+++ b/projects/free.yml
@@ -1287,6 +1287,11 @@ categories:
         - name: SlidingMenu
           url: https://github.com/jfeinstein10/SlidingMenu
 
+    - name: Snackbars
+      projects:
+        - name: SnackbarBuilder
+          url: https://github.com/andrewlord1990/SnackbarBuilder
+
     - name: SOAP
       projects:
         - name: android-soap-enabler


### PR DESCRIPTION
android-arsenal.com/free has a 'Snackbars' section, which this library would go under. This section isn't available on this repo, so I created and put the library under there.

Thanks.