### PR TITLE
Add AndroidVimeoExtractor within Video - Free

### DIFF
--- a/projects/free.yml
+++ b/projects/free.yml
@@ -1614,6 +1614,8 @@ categories:
           url: https://developers.google.com/youtube/android/player
         - name: Ipcam view
           url: https://github.com/niqdev/ipcam-view
+        - name: AndroidVimeoExtractor
+          url: https://github.com/ed-george/AndroidVimeoExtractor
 
     - name: View Pagers
       projects:


### PR DESCRIPTION
Added [AndroidVimeoExtractor](https://github.com/ed-george/AndroidVimeoExtractor) library to the Video - Free section.

Please let me know if this is not the most appropriate section for this library