### PR TITLE
Add android-textoverlay

### DIFF
--- a/projects/free.yml
+++ b/projects/free.yml
@@ -1030,6 +1030,11 @@ categories:
         - name: CPOrm
           url: https://github.com/Wackymax/CPOrm
 
+    - name: Overlays
+      projects:
+        - name: TextOverlay
+          url: https://github.com/saschpe/android-textoverlay
+
     - name: Parallax List Views
       projects:
         - name: ParallaxListView


### PR DESCRIPTION
Provides a simple service that allows to display arbitrary text as a
system-window overlay.