### PR TITLE
Add DontCommit as free tool

### DIFF
--- a/projects/free.yml
+++ b/projects/free.yml
@@ -1575,6 +1575,8 @@ categories:
           url: https://github.com/JakeWharton/madge
         - name: Android Keystore Recovery
           url: https://github.com/rsertelon/android-keystore-recovery
+        - name: DontCommit
+          url: https://github.com/SteveBarnegren/DontCommit
 
     - name: USB
       projects:


### PR DESCRIPTION
Adds [Don't Commit](https://github.com/SteveBarnegren/DontCommit) by Steve Barnegren to the free Tool list.

From README:

> Git hook to prevent commits containing temporary or debug code.
> Any comment beginning with `//!!!` will prevent code from being commited. 