### PR TITLE
Add PlanningPoker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1094,6 +1094,9 @@ Thank you very much in advance!
 ### Video (1)
 * [Kickflip Android Example](https://github.com/Kickflip/kickflip-android-example)
 
+## Wear (1)
+* [Planning Poker](https://github.com/saschpe/PlanningPoker)
+
 
 ## Paid libraries and tools
 ### 3D Engines (2)

--- a/projects/demo.yml
+++ b/projects/demo.yml
@@ -185,6 +185,11 @@ categories:
       projects:
         - name: Kickflip Android Example
           url: https://github.com/Kickflip/kickflip-android-example
+
+    - name: Wear
+      projects:
+        - name: Planning Poker
+          url: https://github.com/saschpe/PlanningPoker
     
     - name: Architecture
       projects:


### PR DESCRIPTION
Real app published on Play Store, Amazon Store and Samsung Store.
Showcases how to do a Phone + Wear1 and standalone Wear2 app.