### PR TITLE
Add saschpe.android:social-fragment

### DIFF
--- a/README.md
+++ b/README.md
@@ -815,6 +815,7 @@ Thank you very much in advance!
 * [SnackEngage](https://github.com/ligi/SnackEngage)
 
 ### Social Networks (7)
+* [AndroidSocialFragment](https://github.com/saschpe/android-social-fragment)
 * [AndroidSocialNetworks](https://github.com/antonkrasov/AndroidSocialNetworks)
 * [Bitlyj](https://code.google.com/p/bitlyj)
 * [Facebook SDK](https://developers.facebook.com/docs/android)

--- a/projects/free.yml
+++ b/projects/free.yml
@@ -1366,6 +1366,8 @@ categories:
 
     - name: Social Networks
       projects:
+        - name: AndroidSocialFragment
+          url: https://github.com/saschpe/android-social-fragment
         - name: AndroidSocialNetworks
           url: https://github.com/antonkrasov/AndroidSocialNetworks
         - name: Bitlyj


### PR DESCRIPTION
A reusable fragment to display links to social networks, the Play Store
as well as recommendation and support email links Edit